### PR TITLE
Portable try/catch

### DIFF
--- a/src/main/clojure/motif/core.cljc
+++ b/src/main/clojure/motif/core.cljc
@@ -227,11 +227,11 @@
    (fn [target]
      (try
        (apply (compile-pattern pattern) [target])
-       (catch Exception e false))))
+       (catch #?(:clj Exception :cljs :default) _ false))))
   ([pattern expr]
    (try
      (apply (compile-pattern pattern) [expr])
-     (catch Exception e false))))
+     (catch #?(:clj Exception :cljs :default) _ false))))
 
 (defmacro match
   "Takes a subject expression, and a set of clauses.


### PR DESCRIPTION
This fixes the
```
Use of undeclared Var motif.core/Exception
```
problem when using motif in a CLJS project.